### PR TITLE
EASY-1413: upgrade to Scala 2.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-prototype</artifactId>
-        <version>1.62</version>
+        <version>1.63-SNAPSHOT</version>
     </parent>
 
     <groupId>nl.knaw.dans.easy</groupId>
@@ -46,8 +46,7 @@
     <dependencies>
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
-            <artifactId>dans-scala-lib</artifactId>
-            <version>1.2</version>
+            <artifactId>dans-scala-lib_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
@@ -55,19 +54,19 @@
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_2.11</artifactId>
+            <artifactId>scalatest_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scalamock</groupId>
-            <artifactId>scalamock-scalatest-support_2.11</artifactId>
+            <artifactId>scalamock-scalatest-support_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scala-lang.modules</groupId>
-            <artifactId>scala-xml_2.11</artifactId>
+            <artifactId>scala-xml_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>org.rogach</groupId>
-            <artifactId>scallop_2.11</artifactId>
+            <artifactId>scallop_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-configuration</groupId>
@@ -79,7 +78,7 @@
         </dependency>
         <dependency>
             <groupId>com.jsuereth</groupId>
-            <artifactId>scala-arm_2.11</artifactId>
+            <artifactId>scala-arm_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>com.yourmediashelf.fedora.client</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-prototype</artifactId>
-        <version>1.63-SNAPSHOT</version>
+        <version>1.64</version>
     </parent>
 
     <groupId>nl.knaw.dans.easy</groupId>

--- a/src/main/scala/nl.knaw.dans.easy.umd/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.umd/Command.scala
@@ -15,13 +15,15 @@
  */
 package nl.knaw.dans.easy.umd
 
+import java.nio.file.Paths
+
 import com.yourmediashelf.fedora.client.FedoraCredentials
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
 object Command extends App with DebugEnhancedLogging {
 
-  val configuration = Configuration()
+  val configuration = Configuration(Paths.get(System.getProperty("app.home")))
   val clo = new CommandLineOptions(args, configuration)
   implicit val settings: Parameters = Parameters(
     test = !clo.doUpdate(),

--- a/src/main/scala/nl.knaw.dans.easy.umd/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.umd/CommandLineOptions.scala
@@ -16,11 +16,8 @@
 package nl.knaw.dans.easy.umd
 
 import java.io.File
-import java.net.URL
 
-import com.yourmediashelf.fedora.client.FedoraCredentials
 import org.rogach.scallop._
-import org.slf4j.{Logger, LoggerFactory}
 
 class CommandLineOptions(args: Array[String], configuration: Configuration) extends ScallopConf(args) {
 

--- a/src/main/scala/nl.knaw.dans.easy.umd/Configuration.scala
+++ b/src/main/scala/nl.knaw.dans.easy.umd/Configuration.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.easy.umd
 
-import java.nio.file.{ Files, Paths }
+import java.nio.file.{ Files, Path, Paths }
 
 import org.apache.commons.configuration.PropertiesConfiguration
 import resource.managed
@@ -26,8 +26,7 @@ case class Configuration(version: String, properties: PropertiesConfiguration)
 
 object Configuration {
 
-  def apply(): Configuration = {
-    val home = Paths.get(System.getProperty("app.home"))
+  def apply(home: Path): Configuration = {
     val cfgPath = Seq(Paths.get(s"/etc/opt/dans.knaw.nl/easy-update-metadata-dataset/"), home.resolve("cfg"))
       .find(Files.exists(_))
       .getOrElse { throw new IllegalStateException("No configuration directory found") }

--- a/src/main/scala/nl.knaw.dans.easy.umd/InputRecord.scala
+++ b/src/main/scala/nl.knaw.dans.easy.umd/InputRecord.scala
@@ -19,14 +19,12 @@ import java.io._
 
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.csv.{ CSVFormat, CSVParser, CSVRecord }
-import org.slf4j.{ Logger, LoggerFactory }
-
-import scala.collection.JavaConverters.iterableAsScalaIterableConverter
-import scala.util.{ Failure, Success, Try }
 import resource._
 
+import scala.collection.JavaConverters.iterableAsScalaIterableConverter
 import scala.collection.immutable.Stream.Empty
 import scala.language.postfixOps
+import scala.util.{ Failure, Try }
 
 /** Defaults to the mandatory header line in the CSV file. */
 case class InputRecord(recordNr: Long = 1,

--- a/src/main/scala/nl.knaw.dans.easy.umd/UpdateMetadataDataset.scala
+++ b/src/main/scala/nl.knaw.dans.easy.umd/UpdateMetadataDataset.scala
@@ -15,12 +15,12 @@
  */
 package nl.knaw.dans.easy.umd
 
-import java.io.{ File, FileInputStream, Reader }
-import java.nio.charset.{ Charset, CodingErrorAction, StandardCharsets }
+import java.io.{ File, Reader }
+import java.nio.charset.{ CodingErrorAction, StandardCharsets }
 
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
-import resource.{ ManagedResource, Using, managed }
+import resource.{ ManagedResource, managed }
 
 import scala.io.Source
 import scala.util.{ Failure, Success, Try }


### PR DESCRIPTION
fixes EASY-1413

#### When applied it will
* upgrade the project to use Scala_2.12 as the compiler
* provide a parameter to the `Configuration` constructor

@DANS-KNAW/easy for review