### PR TITLE
EASY-2316: Add validation for organisation identifiers

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.umd/Transformer.scala
+++ b/src/main/scala/nl.knaw.dans.easy.umd/Transformer.scala
@@ -18,17 +18,17 @@ package nl.knaw.dans.easy.umd
 import org.apache.commons.lang.NotImplementedException
 import org.joda.time.DateTime
 
-import scala.util.{Failure, Success, Try}
+import scala.util.{ Failure, Success, Try }
 import scala.xml._
-import scala.xml.transform.{RewriteRule, RuleTransformer}
+import scala.xml.transform.{ RewriteRule, RuleTransformer }
 
 object Transformer {
 
   def apply(streamID: String, tag: String, oldValue: String, newValue: String): RuleTransformer = {
     (streamID, tag) match {
       case ("AMD", "datasetState") => datasetStateTransformer(oldValue, newValue)
-      case ("EMD", "orgISNI") => organisationIdTransformer(oldValue, newValue, "http://isni.org/isni/"+newValue.replaceAll(" ", ""), "ISNI")
-      case ("EMD", "orgROR") => organisationIdTransformer(oldValue, newValue, "https://"+newValue, "ROR")
+      case ("EMD", "orgISNI") => organisationIdTransformer(oldValue, "http://isni.org", "http://isni.org/isni/" + newValue.replaceAll(" ", ""), "ISNI")
+      case ("EMD", "orgROR") => organisationIdTransformer(oldValue, "https://ror.org", "https://" + newValue, "ROR")
       case _ => plainTransformer(tag, oldValue, newValue)
     }
   }
@@ -64,29 +64,30 @@ object Transformer {
           Elem(prefix, "previousState", attribs, scope, false, Text(oldState))
         case Elem(prefix, "lastStateChange", attribs, scope, _) =>
           Elem(prefix, "lastStateChange", attribs, scope, false, Text(DateTime.now().toString))
-        case Elem(prefix, "stateChangeDates", attribs, scope, children@_*) =>
+        case Elem(prefix, "stateChangeDates", attribs, scope, children @ _*) =>
           Elem(prefix, "stateChangeDates", attribs, scope, false, children ++ newChangeDate(oldState, newState): _*)
         case other => other
       }
     })
   }
 
-  private def organisationIdTransformer(organisationName: String, organisationText: String, organisationURI: String, scheme: String): RuleTransformer = {
+  private def organisationIdTransformer(organisationName: String, schemeURI: String, organisationURI: String, scheme: String): RuleTransformer = {
     new RuleTransformer(new RewriteRule {
       override def transform(n: Node): Seq[Node] = n match {
-        case e:Elem if e.label.equals("organization") && e.text.equals(organisationName) =>
-          e ++ <eas:organizationId eas:identification-system={organisationURI} eas:scheme={scheme}>{scheme}: {organisationText}</eas:organizationId>
+        case e: Elem if e.label.equals("organization") && e.text.equals(organisationName) =>
+          e ++ <eas:organizationId eas:identification-system={schemeURI} eas:scheme={scheme}>{organisationURI}</eas:organizationId>
         case other => other
       }
     })
-
   }
 
   private def newChangeDate(oldState: String, newState: String): Elem = {
+    //@formatter:off
     <damd:stateChangeDate>
       <fromState>{oldState}</fromState>
       <toState>{newState}</toState>
       <changeDate>{DateTime.now().toString}</changeDate>
     </damd:stateChangeDate>
+    //@formatter:on
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.umd/Transformer.scala
+++ b/src/main/scala/nl.knaw.dans.easy.umd/Transformer.scala
@@ -74,7 +74,7 @@ object Transformer {
   private def organisationIdTransformer(organisationName: String, schemeURI: String, organisationURI: String, scheme: String): RuleTransformer = {
     new RuleTransformer(new RewriteRule {
       override def transform(n: Node): Seq[Node] = n match {
-        case e: Elem if e.label.equals("organization") && e.text.equals(organisationName) =>
+        case e: Elem if e.label == "organization" && e.text == organisationName =>
           e ++ <eas:organizationId eas:identification-system={schemeURI} eas:scheme={scheme}>{organisationURI}</eas:organizationId>
         case other => other
       }

--- a/src/main/scala/nl.knaw.dans.easy.umd/Transformer.scala
+++ b/src/main/scala/nl.knaw.dans.easy.umd/Transformer.scala
@@ -34,13 +34,22 @@ object Transformer {
   }
 
   def validate(streamID: String, tag: String, expectedOldValue: String, oldXML: Elem): Try[Unit] = {
-    (streamID, tag, (oldXML \ "datasetState").text, (oldXML \ "previousState").text) match {
-      case ("AMD", "datasetState", _, "") =>
-        Failure(new NotImplementedException("no <previousState> in AMD."))
-      case ("AMD", "datasetState", `expectedOldValue`, _) =>
-        Success(())
-      case ("AMD", "datasetState", actualOldValue, _) =>
-        Failure(new NotImplementedException(s"expected AMD <datasetState> [$expectedOldValue] but found [$actualOldValue]."))
+    (streamID, tag) match {
+      case ("AMD", "datasetState") =>
+        (streamID, tag, (oldXML \ "datasetState").text, (oldXML \ "previousState").text) match {
+          case ("AMD", "datasetState", _, "") =>
+            Failure(new NotImplementedException("no <previousState> in AMD."))
+          case ("AMD", "datasetState", `expectedOldValue`, _) =>
+            Success(())
+          case ("AMD", "datasetState", actualOldValue, _) =>
+            Failure(new NotImplementedException(s"expected AMD <datasetState> [$expectedOldValue] but found [$actualOldValue]."))
+          case _ =>
+            Success(())
+        }
+      case ("EMD", "orgISNI") => {
+        if ((oldXML \\ "organization").exists(_.text == expectedOldValue))  Success(())
+        else Failure(new NotImplementedError(s"no organization with name [$expectedOldValue] found."))
+      }
       case _ =>
         Success(())
     }

--- a/src/test/scala/nl.knaw.dans.easy.umd/IsniTransformerSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.umd/IsniTransformerSpec.scala
@@ -1,0 +1,129 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.umd
+
+import org.scalatest.{FlatSpec, Inside, Matchers, OptionValues}
+
+import scala.xml.PrettyPrinter
+
+class IsniTransformerSpec extends FlatSpec with Matchers with OptionValues with Inside {
+
+
+  "EMD <orgISNI>" should "add ISNI organizationId" in {
+    val inputXML =
+      <emd:easymetadata>
+        <emd:title>
+          <dct:alternative>BAAC Rapport 0427</dct:alternative>
+        </emd:title>
+        <emd:creator>
+          <eas:creator>
+            <eas:title>drs</eas:title>
+            <eas:initials>A</eas:initials>
+            <eas:surname>B</eas:surname>
+            <eas:organization>BAAC</eas:organization>
+            <eas:entityId eas:scheme="DAI"></eas:entityId>
+          </eas:creator>
+          <eas:creator>
+            <eas:title>drs</eas:title>
+            <eas:initials>MC</eas:initials>
+            <eas:surname>R</eas:surname>
+            <eas:organization>BAAC bv</eas:organization>
+            <eas:entityId eas:scheme="DAI"></eas:entityId>
+          </eas:creator>
+        </emd:creator>
+      </emd:easymetadata>
+
+    val expectedXML =
+      <emd:easymetadata>
+        <emd:title>
+          <dct:alternative>BAAC Rapport 0427</dct:alternative>
+        </emd:title>
+        <emd:creator>
+          <eas:creator>
+            <eas:title>drs</eas:title>
+            <eas:initials>A</eas:initials>
+            <eas:surname>B</eas:surname>
+            <eas:organization>BAAC</eas:organization>
+            <eas:entityId eas:scheme="DAI"></eas:entityId>
+          </eas:creator>
+          <eas:creator>
+            <eas:title>drs</eas:title>
+            <eas:initials>MC</eas:initials>
+            <eas:surname>R</eas:surname>
+            <eas:organization>BAAC bv</eas:organization>
+            <eas:organizationId eas:identification-system="http://isni.org/isni/0000000472370000" eas:scheme="ISNI">ISNI: 0000 0004 7237 0000</eas:organizationId>
+            <eas:entityId eas:scheme="DAI"></eas:entityId>
+          </eas:creator>
+        </emd:creator>
+      </emd:easymetadata>
+
+    Transformer("EMD", "orgISNI", "BAAC bv", "0000 0004 7237 0000")
+      .transform(inputXML).headOption.map(new PrettyPrinter(160, 2).format(_))
+      .value shouldBe new PrettyPrinter(160, 2).format(expectedXML)
+  }
+
+  it should "add ROR organizationId" in {
+
+    val inputXML =
+      <emd:easymetadata>
+      <emd:title>
+        <dct:alternative>AMZ Publicaties 2005-12</dct:alternative>
+      </emd:title>
+        <emd:creator>
+          <eas:creator>
+            <eas:initials>J.K.</eas:initials>
+            <eas:prefix>van den</eas:prefix>
+            <eas:surname>Laan</eas:surname>
+            <eas:organization>Andere organisatie</eas:organization>
+            <eas:entityId eas:scheme="DAI"></eas:entityId>
+          </eas:creator>
+          <eas:creator>
+            <eas:initials>J.</eas:initials>
+            <eas:surname>Land</eas:surname>
+            <eas:organization>Hazenberg Archeologie</eas:organization>
+            <eas:entityId eas:scheme="DAI"></eas:entityId>
+          </eas:creator>
+        </emd:creator>
+        </emd:easymetadata>
+
+    val expectedXML =
+      <emd:easymetadata>
+        <emd:title>
+          <dct:alternative>AMZ Publicaties 2005-12</dct:alternative>
+        </emd:title>
+        <emd:creator>
+          <eas:creator>
+            <eas:initials>J.K.</eas:initials>
+            <eas:prefix>van den</eas:prefix>
+            <eas:surname>Laan</eas:surname>
+            <eas:organization>Andere organisatie</eas:organization>
+            <eas:entityId eas:scheme="DAI"></eas:entityId>
+          </eas:creator>
+          <eas:creator>
+            <eas:initials>J.</eas:initials>
+            <eas:surname>Land</eas:surname>
+            <eas:organization>Hazenberg Archeologie</eas:organization>
+            <eas:organizationId eas:identification-system="https://ror.org/01h1amn32" eas:scheme="ROR">ROR: ror.org/01h1amn32</eas:organizationId>
+            <eas:entityId eas:scheme="DAI"></eas:entityId>
+          </eas:creator>
+        </emd:creator>
+      </emd:easymetadata>
+
+    Transformer("EMD", "orgROR", "Hazenberg Archeologie", "ror.org/01h1amn32")
+      .transform(inputXML).headOption.map(new PrettyPrinter(160, 2).format(_))
+      .value shouldBe new PrettyPrinter(160, 2).format(expectedXML)
+  }
+}

--- a/src/test/scala/nl.knaw.dans.easy.umd/IsniTransformerSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.umd/IsniTransformerSpec.scala
@@ -30,8 +30,9 @@
   */
 package nl.knaw.dans.easy.umd
 
-import org.scalatest.{FlatSpec, Inside, Matchers, OptionValues}
+import org.scalatest.{ FlatSpec, Inside, Matchers, OptionValues }
 
+import scala.util.{ Failure, Success }
 import scala.xml.PrettyPrinter
 
 class IsniTransformerSpec extends FlatSpec with Matchers with OptionValues with Inside {
@@ -87,6 +88,62 @@ class IsniTransformerSpec extends FlatSpec with Matchers with OptionValues with 
     Transformer("EMD", "orgISNI", "BAAC bv", "0000 0004 7237 0000")
       .transform(inputXML).headOption.map(new PrettyPrinter(160, 2).format(_))
       .value shouldBe new PrettyPrinter(160, 2).format(expectedXML)
+  }
+
+  it should "reject a dataset that does NOT contain the requested organization" in {
+    val inputXML =
+      <emd:easymetadata>
+        <emd:title>
+          <dct:alternative>BAAC Rapport 0427</dct:alternative>
+        </emd:title>
+        <emd:creator>
+          <eas:creator>
+            <eas:title>drs</eas:title>
+            <eas:initials>A</eas:initials>
+            <eas:surname>B</eas:surname>
+            <eas:organization>BAAC</eas:organization>
+            <eas:entityId eas:scheme="DAI"></eas:entityId>
+          </eas:creator>
+          <eas:creator>
+            <eas:title>drs</eas:title>
+            <eas:initials>MC</eas:initials>
+            <eas:surname>R</eas:surname>
+            <eas:organization>BAAC bv</eas:organization>
+            <eas:entityId eas:scheme="DAI"></eas:entityId>
+          </eas:creator>
+        </emd:creator>
+      </emd:easymetadata>
+
+    inside(Transformer.validate("EMD", "orgISNI", "BAAC 123", inputXML)) {
+      case Failure(e) => e should have message "no organization with name [BAAC 123] found."
+    }
+  }
+
+  it should "validate a dataset that does contain the requested organization" in {
+    val inputXML =
+      <emd:easymetadata>
+        <emd:title>
+          <dct:alternative>BAAC Rapport 0427</dct:alternative>
+        </emd:title>
+        <emd:creator>
+          <eas:creator>
+            <eas:title>drs</eas:title>
+            <eas:initials>A</eas:initials>
+            <eas:surname>B</eas:surname>
+            <eas:organization>BAAC</eas:organization>
+            <eas:entityId eas:scheme="DAI"></eas:entityId>
+          </eas:creator>
+          <eas:creator>
+            <eas:title>drs</eas:title>
+            <eas:initials>MC</eas:initials>
+            <eas:surname>R</eas:surname>
+            <eas:organization>BAAC bv</eas:organization>
+            <eas:entityId eas:scheme="DAI"></eas:entityId>
+          </eas:creator>
+        </emd:creator>
+      </emd:easymetadata>
+
+    Transformer.validate("EMD", "orgISNI", "BAAC bv", inputXML) shouldBe a [Success[_]]
   }
 
   it should "add ROR organizationId" in {

--- a/src/test/scala/nl.knaw.dans.easy.umd/IsniTransformerSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.umd/IsniTransformerSpec.scala
@@ -13,6 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+  * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
 package nl.knaw.dans.easy.umd
 
 import org.scalatest.{FlatSpec, Inside, Matchers, OptionValues}
@@ -20,7 +35,6 @@ import org.scalatest.{FlatSpec, Inside, Matchers, OptionValues}
 import scala.xml.PrettyPrinter
 
 class IsniTransformerSpec extends FlatSpec with Matchers with OptionValues with Inside {
-
 
   "EMD <orgISNI>" should "add ISNI organizationId" in {
     val inputXML =
@@ -64,7 +78,7 @@ class IsniTransformerSpec extends FlatSpec with Matchers with OptionValues with 
             <eas:initials>MC</eas:initials>
             <eas:surname>R</eas:surname>
             <eas:organization>BAAC bv</eas:organization>
-            <eas:organizationId eas:identification-system="http://isni.org/isni/0000000472370000" eas:scheme="ISNI">ISNI: 0000 0004 7237 0000</eas:organizationId>
+            <eas:organizationId eas:identification-system="http://isni.org" eas:scheme="ISNI">http://isni.org/isni/0000000472370000</eas:organizationId>
             <eas:entityId eas:scheme="DAI"></eas:entityId>
           </eas:creator>
         </emd:creator>
@@ -76,12 +90,11 @@ class IsniTransformerSpec extends FlatSpec with Matchers with OptionValues with 
   }
 
   it should "add ROR organizationId" in {
-
     val inputXML =
       <emd:easymetadata>
-      <emd:title>
-        <dct:alternative>AMZ Publicaties 2005-12</dct:alternative>
-      </emd:title>
+        <emd:title>
+          <dct:alternative>AMZ Publicaties 2005-12</dct:alternative>
+        </emd:title>
         <emd:creator>
           <eas:creator>
             <eas:initials>J.K.</eas:initials>
@@ -97,7 +110,7 @@ class IsniTransformerSpec extends FlatSpec with Matchers with OptionValues with 
             <eas:entityId eas:scheme="DAI"></eas:entityId>
           </eas:creator>
         </emd:creator>
-        </emd:easymetadata>
+      </emd:easymetadata>
 
     val expectedXML =
       <emd:easymetadata>
@@ -116,7 +129,7 @@ class IsniTransformerSpec extends FlatSpec with Matchers with OptionValues with 
             <eas:initials>J.</eas:initials>
             <eas:surname>Land</eas:surname>
             <eas:organization>Hazenberg Archeologie</eas:organization>
-            <eas:organizationId eas:identification-system="https://ror.org/01h1amn32" eas:scheme="ROR">ROR: ror.org/01h1amn32</eas:organizationId>
+            <eas:organizationId eas:identification-system="https://ror.org" eas:scheme="ROR">https://ror.org/01h1amn32</eas:organizationId>
             <eas:entityId eas:scheme="DAI"></eas:entityId>
           </eas:creator>
         </emd:creator>


### PR DESCRIPTION
fixes EASY-2316

#### When applied it will
*  check whether the specified 'organization' is mentioned in the dataset when the `doUpdate` commandline option is NOT given

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-update-metadata-dataset                      | [PR#16](https://github.com/DANS-KNAW/easy-update-metadata-dataset/pull/16) 
