### PR TITLE
EASY-2474: Convert documentation to mkdocs

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+GH_ORG=DANS-KNAW
+
+set -e
+
+# Relies on Travis checking out repo to a dir with the repo's name.
+GH_REPO=$(basename $TRAVIS_BUILD_DIR)
+REMOTE="https://${GH_TOKEN}@github.com/${GH_ORG}/${GH_REPO}"
+git remote set-url origin ${REMOTE}
+
+echo "START installing required Python packages..."
+pip3 install mkdocs
+pip3 install pygments
+pip3 install pymdown-extensions
+pip3 install pyyaml
+pip3 install mkdocs-markdownextradata-plugin
+echo "DONE installing required Python packages."
+
+echo "START installing DANS mkdocs theme..."
+git clone https://github.com/Dans-labs/mkdocs-dans $HOME/mkdocs-dans
+pushd $HOME/mkdocs-dans
+git pull
+python3 build.py pack
+popd
+echo "DONE installing DANS mkdocs theme."
+
+echo "START deploying docs to GitHub pages..."
+mkdocs gh-deploy --force
+echo "DONE deploying docs to GitHub pages."

--- a/.travis.sh
+++ b/.travis.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+# Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
-language: java
-jdk: openjdk8
-cache:
-  directories:
-    - "$HOME/.m2/repository"
-script:
-  - "./.travis.sh"
-
+matrix:
+  include:
+    - language: java
+      jdk: openjdk8
+      cache:
+        directories:
+          - "$HOME/.m2/repository"
+    - language: python
+      if: branch = master AND NOT type = pull_request
+      python: 3.7.1
+      cache:
+        directories:
+          - "$HOME/.cache"
+          - "$HOME/virtualenv"
+      script:
+        - "./.travis/mkdocs.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ jdk: openjdk8
 cache:
   directories:
     - "$HOME/.m2/repository"
+script:
+  - "./.travis.sh"
+

--- a/.travis/mkdocs.sh
+++ b/.travis/mkdocs.sh
@@ -24,13 +24,7 @@ GH_REPO=$(basename $TRAVIS_BUILD_DIR)
 REMOTE="https://${GH_TOKEN}@github.com/${GH_ORG}/${GH_REPO}"
 git remote set-url origin ${REMOTE}
 
-echo "START installing required Python packages..."
-pip3 install mkdocs
-pip3 install pygments
-pip3 install pymdown-extensions
-pip3 install pyyaml
-pip3 install mkdocs-markdownextradata-plugin
-echo "DONE installing required Python packages."
+pip install -r .travis/requirements.txt
 
 echo "START installing DANS mkdocs theme..."
 git clone https://github.com/Dans-labs/mkdocs-dans $HOME/mkdocs-dans

--- a/.travis/requirements.txt
+++ b/.travis/requirements.txt
@@ -1,0 +1,5 @@
+mkdocs==1.0.4
+pygments==2.4.2
+pymdown-extensions==6.0
+pyyaml==5.1.2
+mkdocs-markdownextradata-plugin==0.0.6

--- a/README.md
+++ b/README.md
@@ -1,93 +1,10 @@
 easy-update-metadata-dataset
-===========
+============================
 [![Build Status](https://travis-ci.org/DANS-KNAW/easy-update-metadata-dataset.png?branch=master)](https://travis-ci.org/DANS-KNAW/easy-update-metadata-dataset)
 
+Batch-updates XML streams of objects in a Fedora Commons repository. The command is idempotent, so running it either once or multiple times gives the same result.
 
-SYNOPSIS
---------
-
-    easy-update-metadata-dataset [--doUpdate] <datasets.csv>
-
-
-DESCRIPTION
------------
-
-Batch-updates XML streams of objects in a Fedora Commons repository.
-
-
-ARGUMENTS
----------
-
-          --doUpdate   Without this argument no changes are made to the repository, the default is a test mode
-                       that logs the intended changes
-      -h, --help       Show help message
-      -v, --version    Show version of this program
-    
-     trailing arguments:
-      input-file (required)   The CSV file (RFC4180) with required changes. The first line must be
-                              'FEDORA_ID,STREAM_ID,XML_TAG,OLD_VALUE,NEW_VALUE', in that order. Additional columns
-                              and empty lines are ignored.
-
-CONTEXT
+Welcome
 -------
 
-It is the responsibility of the caller to
-
-* Provide _valid_ new values in the input file.
-* Make sure the CSV file is properly stored as UTF8, please export a spreadsheet with open-office for a valid format.
-* Specify all changes for one dataset in subsequent lines, thus at most one dataset will have inconsistent values
-  in case of trouble such as the old value not found or a system failure.
-* Verify the preconditions for stream `AMD` and XML tag `datasetState` which requires a change history.
-  Details are documented with [tests], note that some legitimate preconditions are not implemented and cause a failure,
-  not expected preconditions might pass without a warning.
-* Execute with a representative sample in test mode (without `--doUpdate`) and review the logged changes.
-* Change the streams `DC` and `EMD` alike as far as applicable.
-  In case of `EMD,accessRights` / `DC,rights` also
-  * Update [file rights].
-  * Call [easy-update-fs-rdb].
-  * Reboot the web-ui to clear the [hibernate] cash.
-* Call [easy-task-add-new-license] if EMD and/or file rights were changed, the link requires access to the legacy code base.
-* Update relations such as `hasDoi`, `isMemberOf`, collections ...
-* Call [easy-update-solr-index] if necessary.
-
-The legacy code base provides [CSV examples] for the `deasy` environment.
-
-[easy-update-fs-rdb]: https://github.com/DANS-KNAW/easy-update-fs-rdb
-[file rights]: https://github.com/DANS-KNAW/easy-update-metadata-fileitem
-[hibernate]: http://hibernate.org/
-[easy-task-add-new-license]: https://github.com/DANS-KNAW/easy-app/blob/master/tool/task-add-new-license/README.md
-[easy-update-solr-index]: https://github.com/DANS-KNAW/easy-update-solr-index
-[tests]: src/test/scala/nl/knaw/dans/easy/umd/TransformerSpec.scala
-[CSV examples]: src/test/resources
-
-
-INSTALLATION AND CONFIGURATION
-------------------------------
-Currently this project is built as an RPM package for RHEL7/CentOS7 and later. The RPM will install the binaries to
-`/opt/dans.knaw.nl/easy-update-metadata-dataset` and the configuration files to `/etc/opt/dans.knaw.nl/easy-update-metadata-dataset`. 
-
-To install the module on systems that do not support RPM, you can copy and unarchive the tarball to the target host.
-You will have to take care of placing the files in the correct locations for your system yourself. For instructions
-on building the tarball, see next section.
-
-BUILDING FROM SOURCE
---------------------
-Prerequisites:
-
-* Java 8 or higher
-* Maven 3.3.3 or higher
-* RPM
-
-Steps:
-
-        git clone https://github.com/DANS-KNAW/easy-update-metadata-dataset.git
-        cd easy-update-metadata-dataset
-        mvn clean install
-
-If the `rpm` executable is found at `/usr/local/bin/rpm`, the build profile that includes the RPM 
-packaging will be activated. If `rpm` is available, but at a different path, then activate it by using
-Maven's `-P` switch: `mvn -Pprm install`.
-
-Alternatively, to build the tarball execute:
-
-    mvn clean install assembly:single
+Welcome to the `easy-update-metadata-dataset` project. See the [GitHub pages](https://dans-knaw.github.io/easy-update-metadata-dataset/) for the manual.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,30 +6,31 @@ easy-update-metadata-dataset
 SYNOPSIS
 --------
 
-    easy-update-metadata-dataset [--doUpdate] <datasets.csv>
-
+    easy-update-metadata-dataset [--doUpdate] <input-file> [<complex-values-directory>]
 
 DESCRIPTION
 -----------
 
 Batch-updates XML streams of objects in a Fedora Commons repository.
+The command is idempotent, so running it either once or multiple times gives the same result.
 
 
 ARGUMENTS
 ---------
 
-          --doUpdate   Without this argument no changes are made to the repository, the default is a test mode
-                       that logs the intended changes
-      -h, --help       Show help message
-      -v, --version    Show version of this program
-    
-     trailing arguments:
-      input-file (required)   The CSV file (RFC4180) with required changes. The first line must be
-                              'FEDORA_ID,STREAM_ID,XML_TAG,OLD_VALUE,NEW_VALUE', in that order. Additional columns
-                              and empty lines are ignored.
 
-CONTEXT
--------
+           --doUpdate   Without this argument no changes are made to the repository, the default is a test mode
+                               that logs the intended changes
+       -h, --help       Show help message
+       -v, --version    Show version of this program
+         
+       trailing arguments:
+           input-file (required)                     The CSV file (RFC4180) with required changes. The first line must
+                                                     be 'FEDORA_ID,STREAM_ID,XML_TAG,OLD_VALUE,NEW_VALUE', in that
+                                                     order. Additional columns and empty lines are ignored.
+           complex-values-directory (not required)   A reference to a directory containing files with the complex
+                                                     values. These files are referenced in the input-file.
+
 
 It is the responsibility of the caller to
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,93 @@
+easy-update-metadata-dataset
+============================
+[![Build Status](https://travis-ci.org/DANS-KNAW/easy-update-metadata-dataset.png?branch=master)](https://travis-ci.org/DANS-KNAW/easy-update-metadata-dataset)
+
+
+SYNOPSIS
+--------
+
+    easy-update-metadata-dataset [--doUpdate] <datasets.csv>
+
+
+DESCRIPTION
+-----------
+
+Batch-updates XML streams of objects in a Fedora Commons repository.
+
+
+ARGUMENTS
+---------
+
+          --doUpdate   Without this argument no changes are made to the repository, the default is a test mode
+                       that logs the intended changes
+      -h, --help       Show help message
+      -v, --version    Show version of this program
+    
+     trailing arguments:
+      input-file (required)   The CSV file (RFC4180) with required changes. The first line must be
+                              'FEDORA_ID,STREAM_ID,XML_TAG,OLD_VALUE,NEW_VALUE', in that order. Additional columns
+                              and empty lines are ignored.
+
+CONTEXT
+-------
+
+It is the responsibility of the caller to
+
+* Provide _valid_ new values in the input file.
+* Make sure the CSV file is properly stored as UTF8, please export a spreadsheet with open-office for a valid format.
+* Specify all changes for one dataset in subsequent lines, thus at most one dataset will have inconsistent values
+  in case of trouble such as the old value not found or a system failure.
+* Verify the preconditions for stream `AMD` and XML tag `datasetState` which requires a change history.
+  Details are documented with [tests], note that some legitimate preconditions are not implemented and cause a failure,
+  not expected preconditions might pass without a warning.
+* Execute with a representative sample in test mode (without `--doUpdate`) and review the logged changes.
+* Change the streams `DC` and `EMD` alike as far as applicable.
+  In case of `EMD,accessRights` / `DC,rights` also
+  * Update [file rights].
+  * Call [easy-update-fs-rdb].
+  * Reboot the web-ui to clear the [hibernate] cash.
+* Call [easy-task-add-new-license] if EMD and/or file rights were changed, the link requires access to the legacy code base.
+* Update relations such as `hasDoi`, `isMemberOf`, collections ...
+* Call [easy-update-solr-index] if necessary.
+
+The legacy code base provides [CSV examples] for the `deasy` environment.
+
+[easy-update-fs-rdb]: https://github.com/DANS-KNAW/easy-update-fs-rdb
+[file rights]: https://github.com/DANS-KNAW/easy-update-metadata-fileitem
+[hibernate]: http://hibernate.org/
+[easy-task-add-new-license]: https://github.com/DANS-KNAW/easy-app/blob/master/tool/task-add-new-license/README.md
+[easy-update-solr-index]: https://github.com/DANS-KNAW/easy-update-solr-index
+[tests]: src/test/scala/nl/knaw/dans/easy/umd/TransformerSpec.scala
+[CSV examples]: src/test/resources
+
+
+INSTALLATION AND CONFIGURATION
+------------------------------
+Currently this project is built as an RPM package for RHEL7/CentOS7 and later. The RPM will install the binaries to
+`/opt/dans.knaw.nl/easy-update-metadata-dataset` and the configuration files to `/etc/opt/dans.knaw.nl/easy-update-metadata-dataset`. 
+
+To install the module on systems that do not support RPM, you can copy and unarchive the tarball to the target host.
+You will have to take care of placing the files in the correct locations for your system yourself. For instructions
+on building the tarball, see next section.
+
+BUILDING FROM SOURCE
+--------------------
+Prerequisites:
+
+* Java 8 or higher
+* Maven 3.3.3 or higher
+* RPM
+
+Steps:
+
+        git clone https://github.com/DANS-KNAW/easy-update-metadata-dataset.git
+        cd easy-update-metadata-dataset
+        mvn clean install
+
+If the `rpm` executable is found at `/usr/local/bin/rpm`, the build profile that includes the RPM 
+packaging will be activated. If `rpm` is available, but at a different path, then activate it by using
+Maven's `-P` switch: `mvn -Pprm install`.
+
+Alternatively, to build the tarball execute:
+
+    mvn clean install assembly:single

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,60 @@
+#
+# Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+site_name: easy-update-metadata-dataset
+theme:
+  name: dans
+  disclaimer: false
+
+repo_name: DANS-KNAW/easy-update-metadata-dataset
+repo_url: https://github.com/DANS-KNAW/easy-update-metadata-dataset
+
+nav:
+  - Manual: index.md
+
+plugins:
+  - markdownextradata
+  - search
+
+markdown_extensions:
+  - attr_list
+  #- legacy_attr
+  - admonition
+  - codehilite:
+      guess_lang: false
+  - def_list
+  - footnotes
+  - meta
+  - toc:
+      permalink: true
+  - pymdownx.arithmatex
+  - pymdownx.betterem:
+      smart_enable: all
+  - pymdownx.caret
+  - pymdownx.critic
+  - pymdownx.details
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.magiclink:
+      repo_url_shorthand: true
+      user: Dans-labs
+      repo: mkdocs-dans
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.superfences
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+# Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/scala/nl.knaw.dans.easy.umd/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.umd/CommandLineOptions.scala
@@ -27,7 +27,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   printedName = "easy-update-metadata-dataset"
   version(s"$printedName v${ configuration.version }")
   val description = "Batch-updates XML streams of objects in a Fedora Commons repository."
-  val synopsis = s"$printedName [--doUpdate] <input-file> [<complex_values_directory>]"
+  val synopsis = s"$printedName [--doUpdate] <input-file> [<complex-values-directory>]"
   banner(
     s"""
        |$description
@@ -46,14 +46,14 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   val inputFile: ScallopOption[File] = trailArg[File](name = "input-file",
     descr = "The CSV file (RFC4180) with required changes. The first line must be 'FEDORA_ID,STREAM_ID,XML_TAG,OLD_VALUE,NEW_VALUE', in that order. Additional columns and empty lines are ignored.")
 
-  val complex_values_directory: ScallopOption[File] = trailArg[File](name = "complex_values_directory", required = false,
+  val complexValuesDirectory: ScallopOption[File] = trailArg[File](name = "complex-values-directory", required = false,
     descr = "A reference to a directory containing files with the complex values. These files are referenced in the input-file.")
 
   validateFileExists(inputFile)
   validateFileIsFile(inputFile)
-  
-  validateFileExists(complex_values_directory)
-  validateFileIsDirectory(complex_values_directory)
+
+  validateFileExists(complexValuesDirectory)
+  validateFileIsDirectory(complexValuesDirectory)
 
   footer("")
   verify()

--- a/src/test/scala/nl.knaw.dans.easy.umd/CommandLineOptionsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.umd/CommandLineOptionsSpec.scala
@@ -45,19 +45,19 @@ class CommandLineOptionsSpec extends FlatSpec with Matchers {
     mockedStdOut.toString
   }
 
-  "options in help info" should "be part of README.md" in {
+  "options in help info" should "be part of docs/index.md" in {
     val lineSeparators = s"(${ System.lineSeparator() })+"
     val options = helpInfo.split(s"${ lineSeparators }Options:$lineSeparators")(1)
     options.trim.length shouldNot be(0)
-    new File("README.md") should containTrimmed(options)
+    new File("docs/index.md") should containTrimmed(options)
   }
 
-  "synopsis in help info" should "be part of README.md" in {
-    new File("README.md") should containTrimmed(clo.synopsis)
+  "synopsis in help info" should "be part of docs/index.md" in {
+    new File("docs/index.md") should containTrimmed(clo.synopsis)
   }
 
-  "description line(s) in help info" should "be part of README.md and pom.xml" in {
-    new File("README.md") should containTrimmed(clo.description)
+  "description line(s) in help info" should "be part of docs/index.md and pom.xml" in {
+    new File("docs/index.md") should containTrimmed(clo.description)
     new File("pom.xml") should containTrimmed(clo.description)
   }
 }


### PR DESCRIPTION
fixes EASY-2474

- [x] fix merge conflict

#### When applied it will
* convert the project documentation to mkdocs format

#### Where should the reviewer @DANS-KNAW/easy start?
check out the project, run `mkdocs serve`

#### How should this be manually tested?
https://dans-labs.github.io/mkdocs-dans/