### PR TITLE
EASY-1945: upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>5.1.0</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1</version>
     </parent>
 
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
     </parent>
 
     <groupId>nl.knaw.dans.easy</groupId>

--- a/src/main/scala/nl.knaw.dans.easy.umd/UpdateMetadataDataset.scala
+++ b/src/main/scala/nl.knaw.dans.easy.umd/UpdateMetadataDataset.scala
@@ -71,8 +71,8 @@ object UpdateMetadataDataset extends DebugEnhancedLogging {
     if (oldXML == newXML)
       Failure(new Exception(s"could not find ${record.streamID} <${record.xmlTag}>${record.oldValue}</${record.xmlTag}>"))
     else Try {
-      val oldLines = new PrettyPrinter(160, 2).format(oldXML).lines.toList
-      val newLines = new PrettyPrinter(160, 2).format(newXML.head).lines.toList
+      val oldLines = new PrettyPrinter(160, 2).format(oldXML).linesIterator.toList
+      val newLines = new PrettyPrinter(160, 2).format(newXML.head).linesIterator.toList
 
       logger.info(s"old ${record.streamID}: ${compare(oldLines, newLines)}")
       logger.info(s"new ${record.streamID}: ${compare(newLines, oldLines)}")

--- a/src/test/scala/nl.knaw.dans.easy.umd/CommandSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.umd/CommandSpec.scala
@@ -128,7 +128,7 @@ class CommandSpec extends FlatSpec with Matchers with Inside with MockFactory wi
     implicit val ps: Parameters = Parameters(test = true, fedoraCredentials = null, input = file)
 
     inside(UpdateMetadataDataset.testFriendlyRun(fedoraMock).map(identity).tried.flatten) {
-      case Failure(e) => e should have message "java.nio.charset.MalformedInputException: Input length = 1"
+      case Failure(e) => e should have message "MalformedInputException reading next record: java.nio.charset.MalformedInputException: Input length = 1"
     }
   }
 


### PR DESCRIPTION
Fixes EASY-1945

#### When applied it will
* upgrade parent POM version
* remove self-contained dependency version tags
* change `lines.toList` to `linesIterator.toList` due to https://github.com/scala/bug/issues/11125

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink)
