### PR TITLE
EASY-2646: group_access datasets omzetten naar open_access / restricted

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,21 @@ ARGUMENTS
 EXAMPLES
 --------
 
-### Example: update simple value in EMD
+### Example: update simple value in EMD and DC
 
-This module was developed to update simple values in the EMD, like the AccessCategory. 
+This module was developed to update simple values in EMD and DC, like the AccessCategory. 
 `easy-update-metadata-dataset --doUpdate changeAccessCategory.csv`
 
 ```csv
 FEDORA_ID,      STREAM_ID, XML_TAG,      OLD_VALUE,    NEW_VALUE
 easy-dataset:1, EMD,       accessRights, GROUP_ACCESS, OPEN_ACCESS
 easy-dataset:1, DC,        rights,       GROUP_ACCESS, OPEN_ACCESS
+easy-dataset:1, EMD,       rightsHolder, Owner,        EMPTY
+easy-dataset:1, DC,        rights,       Owner,        EMPTY
 ```
+
+When the new value is "EMPTY" the XML tag will be deleted from EMD/DC.
+
 ### Example: check update datasetState in AMD
 
 To check a potential change of the state of a dataset, use the following

--- a/src/main/scala/nl.knaw.dans.easy.umd/Transformer.scala
+++ b/src/main/scala/nl.knaw.dans.easy.umd/Transformer.scala
@@ -24,6 +24,8 @@ import scala.xml.transform.{ RewriteRule, RuleTransformer }
 
 object Transformer {
 
+  private val EMPTY = "EMPTY"
+
   def apply(streamID: String, tag: String, oldValue: String, newValue: String): RuleTransformer = {
     (streamID, tag) match {
       case ("AMD", "datasetState") => datasetStateTransformer(oldValue, newValue)
@@ -58,6 +60,8 @@ object Transformer {
   private def plainTransformer(label: String, oldValue: String, newValue: String): RuleTransformer =
     new RuleTransformer(new RewriteRule {
       override def transform(n: Node): Seq[Node] = n match {
+        case Elem(_, `label`, _, _, _) if newValue == EMPTY && n.text == oldValue =>
+          NodeSeq.Empty
         case Elem(prefix, `label`, attribs, scope, _) if n.text == oldValue =>
           Elem(prefix, label, attribs, scope, false, Text(newValue))
         case other => other

--- a/src/main/scala/nl.knaw.dans.easy.umd/Transformer.scala
+++ b/src/main/scala/nl.knaw.dans.easy.umd/Transformer.scala
@@ -48,10 +48,9 @@ object Transformer {
           case _ =>
             Success(())
         }
-      case ("EMD", "orgISNI") => {
+      case ("EMD", "orgISNI") =>
         if ((oldXML \\ "organization").exists(_.text == expectedOldValue))  Success(())
         else Failure(new NotImplementedError(s"no organization with name [$expectedOldValue] found."))
-      }
       case _ =>
         Success(())
     }

--- a/src/test/scala/nl.knaw.dans.easy.umd/TransformerSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.umd/TransformerSpec.scala
@@ -46,6 +46,15 @@ class TransformerSpec extends AnyFlatSpec with Matchers with OptionValues with I
       .value shouldBe new PrettyPrinter(160, 2).format(expectedXML)
   }
 
+  it should "delete tag when the new value is EMPTY" in {
+    val inputXML = <someroot><pfx:sometag>Tïtel van de dataset</pfx:sometag><pfx:anothertag>Some content</pfx:anothertag></someroot>
+    val expectedXML = <someroot><pfx:sometag>Tïtel van de dataset</pfx:sometag></someroot>
+
+    Transformer("SOMESTREAMID", "anothertag", "Some content", "EMPTY")
+      .transform(inputXML).headOption.map(new PrettyPrinter(160, 2).format(_))
+      .value shouldBe new PrettyPrinter(160, 2).format(expectedXML)
+  }
+
   "AMD <datasetState>" should "handle initial sword submit" in {
     val inputXML =
       <damd:administrative-md version="0.1">


### PR DESCRIPTION
fixes EASY-2646

#### When applied 
* A tag with a new value `EMPTY` will be deleted from the Fedora stream

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy- access-category-change                     | [PR#1](https://github.com/DANS-KNAW/easy-access-category-change/pull/1) 
