### PR TITLE
EASY-2404: Uitbreiding van easy-update-metadata-dataset: samengestelde velden + waardes toevoegen

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.umd/Transformer.scala
+++ b/src/main/scala/nl.knaw.dans.easy.umd/Transformer.scala
@@ -60,16 +60,10 @@ object Transformer {
   private def addChildTransformer(label: String, newChild: Node): RuleTransformer =
     new RuleTransformer(new RewriteRule {
       override def transform(n: Node): Seq[Node] = n match {
-        case n @ Elem(_, `label`, _, _, _*) => addChild(n, newChild)
+        case Elem(prefix, `label`, attribs, scope, child @ _*) if !childExists(child, newChild) => Elem(prefix, label, attribs, scope, false, child ++ newChild: _*)
         case other => other
       }
     })
-
-  private def addChild(n: Node, newChild: Node) = n match {
-    case Elem(prefix, label, attribs, scope, child @ _*) if !childExists(child, newChild) =>
-      Elem(prefix, label, attribs, scope, false, child ++ newChild: _*)
-    case other => other
-  }
 
   private def childExists(child: Seq[Node], newChild: Node): Boolean = {
     (child contains newChild) || {

--- a/src/test/scala/nl.knaw.dans.easy.umd/CommandSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.umd/CommandSpec.scala
@@ -109,22 +109,6 @@ class CommandSpec extends AnyFlatSpec with Matchers with Inside with MockFactory
     UpdateMetadataDataset.testFriendlyRun(fedoraMock).acquireAndGet(identity) shouldBe a[Success[_]]
   }
 
-  it should "update 1 record, then abort on an inconsistent plain old value" in {
-    // "plain value" as opposed to "AMD <datasetState> value" which is tested with the update method
-    expectUtf8Record(record = 2, fedoraID = 1, stream = "EMD")
-    expectOneFedoraGetXml(Success(<someroot><title>Verkeerde titel van de dataset</title><sometag>tweeën</sometag></someroot>))
-    expectFedoraUpdates(returnValue = Success(()), times = 1)
-
-    val file = new File("src/test/resources/deasy-UTF8-input.csv")
-    implicit val ps: Parameters = Parameters(test = true, fedoraCredentials = null, input = file)
-
-    inside(UpdateMetadataDataset.testFriendlyRun(fedoraMock).acquireAndGet(identity)) {
-      case Failure(e) => e should have message "failed to process: InputRecord(3,easy-dataset:1,DC," +
-        "title,Titel van de dataset,Planetoïde van issue EASY-1128), reason: could not find DC " +
-        "<title>Titel van de dataset</title>"
-    }
-  }
-
   it should "reject CSV when UTF-8 decoding finds invalid characters" in {
     val file = new File("src/test/resources/macroman.txt")
     implicit val ps: Parameters = Parameters(test = true, fedoraCredentials = null, input = file)

--- a/src/test/scala/nl.knaw.dans.easy.umd/TransformerSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.umd/TransformerSpec.scala
@@ -55,6 +55,25 @@ class TransformerSpec extends AnyFlatSpec with Matchers with OptionValues with I
       .value shouldBe new PrettyPrinter(160, 2).format(expectedXML)
   }
 
+  it should "add a new tag in a given parent element when the old value is EMPTY" in {
+    val inputXML = <someroot><somegroup><pfx:sometag>Tïtel van de dataset</pfx:sometag></somegroup></someroot>
+    val expectedXML = <someroot><somegroup><pfx:sometag>Tïtel van de dataset</pfx:sometag><pfx:newtag>Something new</pfx:newtag></somegroup></someroot>
+
+    Transformer("SOMESTREAMID", "somegroup", "EMPTY", "<pfx:newtag>Something new</pfx:newtag>")
+      .transform(inputXML).headOption.map(new PrettyPrinter(160, 2).format(_))
+      .value shouldBe new PrettyPrinter(160, 2).format(expectedXML)
+  }
+
+  it should "not add a new tag in a given parent element if the new tag exists already" in {
+    val inputXML = <someroot><somegroup><pfx:sometag>Tïtel van de dataset</pfx:sometag></somegroup></someroot>
+    val expectedXML = <someroot><somegroup><pfx:sometag>Tïtel van de dataset</pfx:sometag><pfx:newtag>Something new</pfx:newtag></somegroup></someroot>
+
+    val newXml = Transformer("SOMESTREAMID", "somegroup", "EMPTY", "<pfx:newtag>Something new</pfx:newtag>").transform(inputXML)
+    Transformer("SOMESTREAMID", "somegroup", "EMPTY", "<pfx:newtag>Something new</pfx:newtag>").transform(newXml)
+      .headOption.map(new PrettyPrinter(160, 2).format(_))
+      .value shouldBe new PrettyPrinter(160, 2).format(expectedXML)
+  }
+
   "AMD <datasetState>" should "handle initial sword submit" in {
     val inputXML =
       <damd:administrative-md version="0.1">


### PR DESCRIPTION
fixes EASY-2404

#### When applied it is possible
* to add a `new element` in a datastream

The new element can be a simple element like 

     <dct:license>http://creativecommons.org/licenses/by/4.0</dct:license>

or it can be a complex element like 

  ```
<emd:rights>
    <dct:accessRights eas:schemeId="common.dcterms.accessrights">OPEN_ACCESS</dct:accessRights>
    <dct:license>accept</dct:license>
    <dct:license>http://creativecommons.org/licenses/by/4.0</dct:license>
  </emd:rights>
```

The new element is given as an inline parameter, and it is added to the given parent element. In this example \<dct:license\> element is added to \<emd:rights\> parent element:

  `easy-dataset:7,EMD,rights,EMPTY, 
         <dct:license>http://creativecommons.org/licenses/by/4.0</dct:license>`

This command is `idempotent` likewise the other commands in easy-update-metadata.  But you have to take the following in account:  If we would add the complex element here above (<emd:rights>), and then run the same command again, the new element would be added again.  It is because even though we don't give any attributes for <emd:rights> node, they will be deduced.  We have to give the attributes explicitly.  In this case:

```
<emd:rights xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:eas="http://easy.dans.knaw.nl/easy/easymetadata/eas/" xmlns:emd="http://easy.dans.knaw.nl/easy/easymetadata/" emd:version="0.1"> 
   <dct:accessRights eas:schemeId="common.dcterms.accessrights">OPEN_ACCESS</dct:accessRights>
   <dct:license>accept</dct:license>
   <dct:license>http://creativecommons.org/licenses/by/4.0</dct:license>
</emd:rights> 
```


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
