### PR TITLE
EASY-2736: easy-update-metadata-dataset levert invalide EMD op

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.umd/Transformer.scala
+++ b/src/main/scala/nl.knaw.dans.easy.umd/Transformer.scala
@@ -69,7 +69,8 @@ object Transformer {
   private def addLicenseTransformer(label: String, newChild: Node): RuleTransformer =
     new RuleTransformer(new RewriteRule {
       override def transform(n: Node): Seq[Node] = n match {
-        case Elem(prefix, `label`, attribs, scope, child @ _*) if !childExists(child, newChild) => Elem(prefix, label, attribs, scope, false, childrenWithNewLicense(child, newChild): _*)
+        case Elem(prefix, `label`, attribs, scope, child @ _*) if !childExists(child, newChild) =>
+          Elem(prefix, label, attribs, scope, false, childrenWithNewLicense(child, newChild): _*)
         case other => other
       }
     })

--- a/src/test/scala/nl.knaw.dans.easy.umd/TransformerSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.umd/TransformerSpec.scala
@@ -74,6 +74,44 @@ class TransformerSpec extends AnyFlatSpec with Matchers with OptionValues with I
       .value shouldBe new PrettyPrinter(160, 2).format(expectedXML)
   }
 
+  it should "add in EMD a new license tag in a given parent element, before rightsHolder tag, when the old value is EMPTY" in {
+    val inputXML = <someroot>
+      <emd:rights>
+        <dct:accessRights eas:schemeId="common.dcterms.accessrights">OPEN_ACCESS</dct:accessRights>
+        <dct:rightsHolder>BAAC</dct:rightsHolder>
+      </emd:rights>
+    </someroot>
+    val expectedXML = <someroot>
+      <emd:rights>
+        <dct:accessRights eas:schemeId="common.dcterms.accessrights">OPEN_ACCESS</dct:accessRights>
+        <dct:license>http://creativecommons.org/licenses/by/4.0</dct:license>
+        <dct:rightsHolder>BAAC</dct:rightsHolder>
+      </emd:rights>
+    </someroot>
+
+    Transformer("EMD", "rights", "EMPTY", "<dct:license>http://creativecommons.org/licenses/by/4.0</dct:license>")
+      .transform(inputXML).headOption.map(new PrettyPrinter(160, 2).format(_))
+      .value shouldBe new PrettyPrinter(160, 2).format(expectedXML)
+  }
+
+  it should "add in EMD a new license tag as last in emd:rights when there is no rightsHolder tag" in {
+    val inputXML = <someroot>
+      <emd:rights>
+        <dct:accessRights eas:schemeId="common.dcterms.accessrights">OPEN_ACCESS</dct:accessRights>
+      </emd:rights>
+    </someroot>
+    val expectedXML = <someroot>
+      <emd:rights>
+        <dct:accessRights eas:schemeId="common.dcterms.accessrights">OPEN_ACCESS</dct:accessRights>
+        <dct:license>http://creativecommons.org/licenses/by/4.0</dct:license>
+      </emd:rights>
+    </someroot>
+
+    Transformer("EMD", "rights", "EMPTY", "<dct:license>http://creativecommons.org/licenses/by/4.0</dct:license>")
+      .transform(inputXML).headOption.map(new PrettyPrinter(160, 2).format(_))
+      .value shouldBe new PrettyPrinter(160, 2).format(expectedXML)
+  }
+
   "AMD <datasetState>" should "handle initial sword submit" in {
     val inputXML =
       <damd:administrative-md version="0.1">


### PR DESCRIPTION
fixes EASY-2736

#### When applied it will
* add a new `license` in `EMD` in a proper place, before `rightsHolder` tag, or if there is no `rightsHolder` tag, then as the `last tag` in `emd:rights` element

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
