### PR TITLE
DD-937: update datasetState even when there was no previousState

### DIFF
--- a/src/test/scala/nl.knaw.dans.easy.umd/CommandSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.umd/CommandSpec.scala
@@ -69,20 +69,6 @@ class CommandSpec extends AnyFlatSpec with Matchers with Inside with MockFactory
     }
   }
 
-  it should "report a missing previousState" in {
-    expectOneFedoraGetXml(Success(<someroot><sometag>first value</sometag> <sometag>second value</sometag></someroot>))
-
-    val inputRecord = InputRecord(fedoraID = "easy-dataset:1", streamID = "AMD", xmlTag = "datasetState", newValue = "new", oldValue = "first value")
-    implicit val parameters: Parameters = Parameters(test = true, fedoraCredentials = null, input = null)
-
-    inside(UpdateMetadataDataset.update(fedoraMock)(inputRecord)) {
-      case Failure(e) =>
-        e should have message "failed to process: InputRecord(1,easy-dataset:1,AMD,datasetState,first value,new)" +
-          ", reason: no <previousState> in AMD."
-        e.getCause.getMessage should include("previousState")
-    }
-  }
-
   it should "report an inconsistent old AMD <datasetState> value" in {
     expectOneFedoraGetXml(Success(<someroot><datasetState>first value</datasetState> <previousState>second value</previousState></someroot>))
 

--- a/src/test/scala/nl.knaw.dans.easy.umd/TransformerSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.umd/TransformerSpec.scala
@@ -21,7 +21,7 @@ import org.scalatest.{ Inside, OptionValues }
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.util.Failure
+import scala.util.{ Failure, Success }
 import scala.xml.PrettyPrinter
 
 class TransformerSpec extends AnyFlatSpec with Matchers with OptionValues with Inside {
@@ -239,10 +239,8 @@ class TransformerSpec extends AnyFlatSpec with Matchers with OptionValues with I
         </damd:workflowData>
       </damd:administrative-md>
 
-    Transformer.validate("AMD", "datasetState", "PUBLISHED", inputXML) should matchPattern {
-      case Failure(e: NotImplementedException) if e.getMessage == "no <previousState> in AMD." =>
-    }
-    Transformer("AMD", "datasetState", "PUBLISHED", "MAINTENANCE")
+    Transformer.validate("AMD", "datasetState", "PUBLISHED", inputXML) shouldBe a[Success[_]]
+    Transformer("AMD", "datasetState", "PUBLISHED", "MAINTENANCE", isFirstDatesetStateChange = true)
       .transform(inputXML).headOption.map(new PrettyPrinter(160, 2).format(_))
       .value shouldBe new PrettyPrinter(160, 2).format(expectedXML)
   }
@@ -300,7 +298,7 @@ class TransformerSpec extends AnyFlatSpec with Matchers with OptionValues with I
     }
   }
 
-  it should "reject an initial web-ui draft because a missing <previousState> is not implemented" in {
+  it should "accept an initial web-ui draft because a missing <previousState> is now implemented" in {
     val inputXML =
       <damd:administrative-md version="0.1">
         <datasetState>DRAFT</datasetState>
@@ -313,8 +311,6 @@ class TransformerSpec extends AnyFlatSpec with Matchers with OptionValues with I
         </damd:workflowData>
       </damd:administrative-md>
 
-    inside(Transformer.validate("AMD", "datasetState", "DRAFT", inputXML)) {
-      case Failure(e) => e should have message "no <previousState> in AMD."
-    }
+    Transformer.validate("AMD", "datasetState", "DRAFT", inputXML) shouldBe a[Success[_]]
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.umd/TransformerSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.umd/TransformerSpec.scala
@@ -212,11 +212,6 @@ class TransformerSpec extends AnyFlatSpec with Matchers with OptionValues with I
         <datasetState>PUBLISHED</datasetState>
         <depositorId>user001</depositorId>
         <stateChangeDates/>
-        <groupIds/>
-        <damd:workflowData version="0.1">
-          <assigneeId>NOT_ASSIGNED</assigneeId>
-          <wfs:workflow>...</wfs:workflow>
-        </damd:workflowData>
       </damd:administrative-md>
 
     val expectedXML =
@@ -232,11 +227,6 @@ class TransformerSpec extends AnyFlatSpec with Matchers with OptionValues with I
             <changeDate>2016-12-09T13:52:51.089+01:00</changeDate>
           </damd:stateChangeDate>
         </stateChangeDates>
-        <groupIds/>
-        <damd:workflowData version="0.1">
-          <assigneeId>NOT_ASSIGNED</assigneeId>
-          <wfs:workflow>...</wfs:workflow>
-        </damd:workflowData>
       </damd:administrative-md>
 
     Transformer.validate("AMD", "datasetState", "PUBLISHED", inputXML) shouldBe a[Success[_]]

--- a/src/test/scala/nl.knaw.dans.easy.umd/TransformerSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.umd/TransformerSpec.scala
@@ -15,11 +15,10 @@
  */
 package nl.knaw.dans.easy.umd
 
-import org.apache.commons.lang.NotImplementedException
 import org.joda.time.{ DateTime, DateTimeUtils, DateTimeZone }
-import org.scalatest.{ Inside, OptionValues }
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.{ Inside, OptionValues }
 
 import scala.util.{ Failure, Success }
 import scala.xml.PrettyPrinter
@@ -207,7 +206,6 @@ class TransformerSpec extends AnyFlatSpec with Matchers with OptionValues with I
       .value shouldBe new PrettyPrinter(160, 2).format(expectedXML)
   }
 
-
   "AMD <datasetState>" should "set maintenance on immediately published datasets" in {
     val inputXML =
       <damd:administrative-md version="0.1">
@@ -216,8 +214,8 @@ class TransformerSpec extends AnyFlatSpec with Matchers with OptionValues with I
         <stateChangeDates/>
         <groupIds/>
         <damd:workflowData version="0.1">
-        <assigneeId>NOT_ASSIGNED</assigneeId>
-        <wfs:workflow>...</wfs:workflow>
+          <assigneeId>NOT_ASSIGNED</assigneeId>
+          <wfs:workflow>...</wfs:workflow>
         </damd:workflowData>
       </damd:administrative-md>
 
@@ -233,7 +231,9 @@ class TransformerSpec extends AnyFlatSpec with Matchers with OptionValues with I
             <toState>MAINTENANCE</toState>
             <changeDate>2016-12-09T13:52:51.089+01:00</changeDate>
           </damd:stateChangeDate>
-        </stateChangeDates> <groupIds/> <damd:workflowData version="0.1">
+        </stateChangeDates>
+        <groupIds/>
+        <damd:workflowData version="0.1">
           <assigneeId>NOT_ASSIGNED</assigneeId>
           <wfs:workflow>...</wfs:workflow>
         </damd:workflowData>


### PR DESCRIPTION
fixes DD-937 : update datasetState even when there was no previousState

#### When applied it will
* when present old `datasetState` and `lastStateChange` are removed
* new values for `datasetState` and `lastStateChange` are added
* `lastStateChange` will get exactly the same value as the new entry in `stateChangeDates`

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

* [x] run.sh with something like the the following csv

      FEDORA_ID,STREAM_ID,XML_TAG,OLD_VALUE,NEW_VALUE,
      easy-dataset:29,AMD,datasetState,PUBLISHED,MAINTENANCE

  logging shows:

        [2022-04-25 09:21:26,081] INFO  InputRecord(2,easy-dataset:29,AMD,datasetState,PUBLISHED,MAINTENANCE) 
        [2022-04-25 09:21:26,543] INFO  old AMD: 
                  <datasetState>PUBLISHED</datasetState>
                  <stateChangeDates/> 
        [2022-04-25 09:21:26,545] INFO  new AMD: 
                  <datasetState>MAINTENANCE</datasetState>
                  <previousState>PUBLISHED</previousState>
                  <lastStateChange>2022-04-25T09:21:26.420+02:00</lastStateChange>
                  <stateChangeDates>
                    <damd:stateChangeDate>
                      <fromState>PUBLISHED</fromState>
                      <toState>MAINTENANCE</toState>
                      <changeDate>2022-04-25T09:21:26.420+02:00</changeDate>
                    </damd:stateChangeDate>
                  </stateChangeDates> 

  examinig http://deasy.dans.knaw.nl:8080/fedora/objects/easy-dataset:29/datastreams/AMD/content before and after showd the dataset changed

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
